### PR TITLE
Enable SNS Validation for Lambda SNS Triggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 /.tox
 /dist
 /htmlcov
+
+.idea/

--- a/src/validatesns/__init__.py
+++ b/src/validatesns/__init__.py
@@ -65,7 +65,7 @@ def validate(
 
     # Passed the basic checks, let's download the cert.
     # We've validated the URL, so aren't worried about a malicious server.
-    certificate = get_certificate(message["SigningCertURL"])
+    certificate = get_certificate(message.get('SigningCertUrl') or message['SigningCertURL'])
 
     # Check the cryptographic signature.
     SignatureValidator(certificate).validate(message)

--- a/src/validatesns/__init__.py
+++ b/src/validatesns/__init__.py
@@ -191,13 +191,11 @@ class SignatureValidator(object):
     def _get_signing_keys(self, message):
         message_type = message.get("Type")
 
-        if message_type == "Notification":
-            if "Subject" in message:
-                return ("Message", "MessageId", "Subject", "Timestamp", "TopicArn", "Type")
+        if message_type is not None and message_type in ("SubscriptionConfirmation", "UnsubscribeConfirmation"):
+            return "Message", "MessageId", "SubscribeURL", "Timestamp", "Token", "TopicArn", "Type"
+
+        else:
+            if message.get('Subject') is not None:
+                return "Message", "MessageId", "Subject", "Timestamp", "TopicArn", "Type"
             else:
-                return ("Message", "MessageId", "Timestamp", "TopicArn", "Type",)
-
-        if message_type in ("SubscriptionConfirmation", "UnsubscribeConfirmation"):
-            return ("Message", "MessageId", "SubscribeURL", "Timestamp", "Token", "TopicArn", "Type")
-
-        raise ValidationError("Unknown message type {!r}".format(message_type))
+                return "Message", "MessageId", "Timestamp", "TopicArn", "Type"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5,8 +5,7 @@ import unittest
 import mock
 import oscrypto.asymmetric
 import six
-
-from validatesns import MessageAgeValidator, SignatureValidator, ValidationError, validate as _validate_fn
+from validatesns import SignatureValidator, ValidationError, validate as _validate_fn
 
 PRIVATE_KEY = six.b("""
 -----BEGIN PRIVATE KEY-----
@@ -102,6 +101,7 @@ class TestMixin(object):
     def serialize_datetime(self, dt):
         return dt.strftime("%Y-%m-%dT%H:%M:%S.{}Z".format(dt.strftime("%f")[:3]))
 
+
 class ValidateTestCase(TestMixin, unittest.TestCase):
     def test_invalid_max_age_parameter(self):
         self.validate_kwargs["max_age"] = 5
@@ -112,6 +112,7 @@ class ValidateTestCase(TestMixin, unittest.TestCase):
         self.message = []
         with self.assertRaisesRegexp(ValidationError, r"^Unexpected message type .*$"):
             self.validate()
+
 
 class SigningCertURLValidatorTestCase(TestMixin, unittest.TestCase):
     def test_valid_com_signing_cert_url(self):
@@ -144,6 +145,7 @@ class SigningCertURLValidatorTestCase(TestMixin, unittest.TestCase):
         with self.assertRaisesRegexp(ValidationError, r"^SigningCertURL .* doesn't match required format .*"):
             self.validate()
 
+
 class MessageAgeValidatorTestCase(TestMixin, unittest.TestCase):
     def test_valid_age(self):
         self.message["Timestamp"] = self.serialize_datetime(self.utc_now)
@@ -174,6 +176,7 @@ class MessageAgeValidatorTestCase(TestMixin, unittest.TestCase):
         self.message["Timestamp"] = "January 5 2015"
         with self.assertRaisesRegexp(ValidationError, r"^Unexpected Timestamp format .*$"):
             self.validate()
+
 
 class SignatureValidatorTestCase(TestMixin, unittest.TestCase):
     def test_missing_signature_version(self):


### PR DESCRIPTION
The library appears to have initially been created for just HTTP SNS notifications, made some minor changes so that it also supports validating SNS triggers for Lambdas.