### PR TITLE
Support non-ASCII chars in SNS message

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-oscrypto
+oscrypto==0.16.0
 six

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     tests_require=[
         "mock",
-        "oscrypto",
+        "oscrypto==0.16.0",
         "six"
     ],
     classifiers=[

--- a/src/validatesns/__init__.py
+++ b/src/validatesns/__init__.py
@@ -155,7 +155,7 @@ class SignatureValidator(object):
             certificate = certificate.encode()
 
         if isinstance(content, six.text_type):
-            content = content.encode()
+            content = content.encode("utf-8")
 
         try:
             oscrypto.asymmetric.rsa_pkcs1v15_verify(


### PR DESCRIPTION
When a message contains any non-ASCII chars the code raises an exception while converting unicode string to 'ascii' (default) encoding with `decode()` method. And it works fine when we decode it to 'utf-8'